### PR TITLE
feat(nix): adds home manager to flake & hardcoded system

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1740845322,
-        "narHash": "sha256-AXEgFj3C0YJhu9k1OhbRhiA6FnDr81dQZ65U3DhaWpw=",
+        "lastModified": 1741955947,
+        "narHash": "sha256-2lbURKclgKqBNm7hVRtWh0A7NrdsibD0EaWhahUVhhY=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "fcac3d6d88302a5e64f6cb8014ac785e08874c8d",
+        "rev": "4e12151c9e014e2449e0beca2c0e9534b96a26b4",
         "type": "github"
       },
       "original": {
@@ -22,11 +22,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1740828860,
-        "narHash": "sha256-cjbHI+zUzK5CPsQZqMhE3npTyYFt9tJ3+ohcfaOF/WM=",
+        "lastModified": 1742069588,
+        "narHash": "sha256-C7jVfohcGzdZRF6DO+ybyG/sqpo1h6bZi9T56sxLy+k=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "303bd8071377433a2d8f76e684ec773d70c5b642",
+        "rev": "c80f6a7e10b39afcc1894e02ef785b1ad0b0d7e5",
         "type": "github"
       },
       "original": {
@@ -38,11 +38,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1740865531,
-        "narHash": "sha256-h00vGIh/jxcGl8aWdfnVRD74KuLpyY3mZgMFMy7iKIc=",
+        "lastModified": 1741862977,
+        "narHash": "sha256-prZ0M8vE/ghRGGZcflvxCu40ObKaB+ikn74/xQoNrGQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5ef6c425980847c78a80d759abc476e941a9bf42",
+        "rev": "cdd2ef009676ac92b715ff26630164bb88fec4e0",
         "type": "github"
       },
       "original": {

--- a/home-manager/home.nix
+++ b/home-manager/home.nix
@@ -1,4 +1,4 @@
-{ homeStateVersion, user, ... }: {
+{ pkgs, homeStateVersion, user, ... }: {
   imports = [
     ./modules
     ./home-packages.nix

--- a/hosts/konoha/configuration.nix
+++ b/hosts/konoha/configuration.nix
@@ -4,6 +4,7 @@
   imports = [
     ./hardware-configuration.nix
     ./local-packages.nix
+    ./ssh.nix
     ../../nixos/modules
   ];
 

--- a/hosts/konoha/ssh.nix
+++ b/hosts/konoha/ssh.nix
@@ -1,0 +1,16 @@
+{
+  services.openssh = {
+    enable = true;
+    ports = [ 22 ];
+    settings = {
+      PasswordAuthentication = true;
+      AllowUsers = null; # Allows all users by default. Can be [ "user1" "user2" ]
+      UseDns = true;
+      X11Forwarding = true;
+      PermitRootLogin = "prohibit-password"; # "yes", "without-password", "prohibit-password", "forced-commands-only", "no"
+    };
+  };
+
+  networking.firewall.allowedTCPPorts = [ 22 ];
+}
+


### PR DESCRIPTION
Update the `flake.lock` file to use the latest revisions and hashes for `home-manager` and `nixpkgs` repositories. This ensures the project uses the most recent versions of dependencies.

Modify `flake.nix` to include specific system architecture for each host. This change allows for better handling of different system architectures, ensuring configurations are correctly applied.

Add `ssh.nix` to `konoha` host configuration to enable and configure OpenSSH service. This addition allows for remote access and management of the `konoha` host.

Update `home-manager/home.nix` to include `pkgs` in the argument list, ensuring the correct packages are used in home-manager configurations.